### PR TITLE
Feature/todo checked rate

### DIFF
--- a/src/main/java/com/eroom/erooja/domain/model/MemberGoal.java
+++ b/src/main/java/com/eroom/erooja/domain/model/MemberGoal.java
@@ -24,7 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = {"uid"}, callSuper = false)
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -52,9 +52,6 @@ public class MemberGoal extends AuditProperties {
 
     private LocalDateTime endDt;
 
-    // 0.0 ~ 1.0, (체크한 투두 수) / (전체 할 일 수) 비율
-    private Double checkedTodoRate;
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_id", updatable = false, insertable = false)
@@ -71,7 +68,7 @@ public class MemberGoal extends AuditProperties {
 
     @Builder
     public MemberGoal(LocalDateTime createDt, LocalDateTime updateDt, String uid,
-                      Long goalId, GoalRole role, Boolean isEnd, int copyCount, Double checkedTodoRate,
+                      Long goalId, GoalRole role, Boolean isEnd, int copyCount,
                       LocalDateTime startDt, LocalDateTime endDt) {
         super(createDt, updateDt);
         this.uid = uid;
@@ -79,7 +76,6 @@ public class MemberGoal extends AuditProperties {
         this.role = role;
         this.isEnd = isEnd;
         this.copyCount = copyCount;
-        this.checkedTodoRate = checkedTodoRate;
         this.startDt = startDt;
         this.endDt = endDt;
     }

--- a/src/main/java/com/eroom/erooja/features/membergoal/controller/MemberGoalContoller.java
+++ b/src/main/java/com/eroom/erooja/features/membergoal/controller/MemberGoalContoller.java
@@ -3,7 +3,6 @@ package com.eroom.erooja.features.membergoal.controller;
 import com.eroom.erooja.common.exception.EroojaException;
 import com.eroom.erooja.domain.model.JobInterest;
 import com.eroom.erooja.domain.model.MemberGoal;
-import com.eroom.erooja.domain.model.MemberJobInterest;
 import com.eroom.erooja.domain.model.Members;
 import com.eroom.erooja.features.auth.jwt.JwtTokenProvider;
 import com.eroom.erooja.features.goal.service.GoalService;
@@ -19,7 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
@@ -77,27 +75,17 @@ public class MemberGoalContoller {
 
     @GetMapping
     public ResponseEntity getGoalJoinListByUid(GoalJoinListRequestDTO goalJoinListRequestDTO) {
-        Page<MemberGoal> goalJoinPageByUid
+        Page<GoalJoinMemberDTO> memberGoalDTOPage
                 = (goalJoinListRequestDTO.isEndDtIsBeforeNow()) ?
-                memberGoalService.getGoalJoinPageByUidAndEndDtBeforeNow(
+                memberGoalService.getEndedGoalJoinPageByUid(
                         goalJoinListRequestDTO.getUid(),
                         goalJoinListRequestDTO.getPageable())
                 :
-                memberGoalService.getGoalJoinPageByUidAndEndDtAfterNow(
+                memberGoalService.getGoalJoinPageByUid(
                         goalJoinListRequestDTO.getUid(),
                         goalJoinListRequestDTO.getPageable());
 
-        Page<GoalJoinMemberDTO> memberGoalPage = convertPage2DTO(goalJoinPageByUid);
-
-        return ResponseEntity.ok(memberGoalPage);
-    }
-
-    private Page<GoalJoinMemberDTO> convertPage2DTO(Page<MemberGoal> origin) {
-        return new PageImpl<>(
-                origin.getContent().stream()
-                        .map(mg -> GoalJoinMemberDTO.of(mg, goalService.findGoalById(mg.getGoalId())))
-                        .collect(Collectors.toList()),
-                origin.getPageable(), origin.getTotalElements());
+        return ResponseEntity.ok(memberGoalDTOPage);
     }
 
     @GetMapping("/{goalId}/todo")

--- a/src/main/java/com/eroom/erooja/features/membergoal/dto/GoalJoinMemberDTO.java
+++ b/src/main/java/com/eroom/erooja/features/membergoal/dto/GoalJoinMemberDTO.java
@@ -3,6 +3,8 @@ package com.eroom.erooja.features.membergoal.dto;
 import com.eroom.erooja.domain.enums.GoalRole;
 import com.eroom.erooja.domain.model.Goal;
 import com.eroom.erooja.domain.model.MemberGoal;
+import com.eroom.erooja.domain.model.Todo;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +25,7 @@ public class GoalJoinMemberDTO {
 
     private int copyCount;
 
-    private int checkedTodoRate;
+    private double checkedTodoRate;
 
     private LocalDateTime startDt;
 
@@ -32,14 +34,17 @@ public class GoalJoinMemberDTO {
     MinimalGoalDetailDTO minimalGoalDetail;
 
     public static GoalJoinMemberDTO of(MemberGoal memberGoal, Goal goal) {
+        List<Todo> todoList = memberGoal.getTodoList();
+        double checkedTodoRate = todoList.stream().filter(Todo::getIsEnd).count() / (double) todoList.size();
+
         return GoalJoinMemberDTO.builder()
                     .goalId(memberGoal.getGoalId())
                     .role(memberGoal.getRole())
                     .isEnd(memberGoal.getIsEnd())
                     .copyCount(memberGoal.getCopyCount())
-                    .checkedTodoRate((int) (memberGoal.getCheckedTodoRate() * 100))
                     .startDt(memberGoal.getStartDt())
                     .endDt(memberGoal.getEndDt())
+                    .checkedTodoRate(checkedTodoRate)
                     .minimalGoalDetail(MinimalGoalDetailDTO.of(goal))
                 .build();
     }

--- a/src/main/java/com/eroom/erooja/features/membergoal/repository/MemberGoalRepository.java
+++ b/src/main/java/com/eroom/erooja/features/membergoal/repository/MemberGoalRepository.java
@@ -20,9 +20,10 @@ public interface MemberGoalRepository extends JpaRepository<MemberGoal, MemberGo
     int countMemberGoalByGoalId(Long goalId);
 
     Page<GoalJoinTodoDto> getJoinTodoListByGoalId(Long goalId, Pageable pageable);
+
     Page<MemberGoal> findAllByGoalId(Long goalId, Pageable pageable);
 
-    Page<MemberGoal> findAllByUidAndEndDtIsAfter(String uid, Pageable pageable, LocalDateTime now);
+    Page<MemberGoal> findAllByUidAndEndDtIsAfterOrIsEndTrue(String uid, Pageable pageable, LocalDateTime now);
 
-    Page<MemberGoal> findAllByUidAndEndDtIsBefore(String uid, Pageable pageable, LocalDateTime now);
+    Page<MemberGoal> findAllByUidAndEndDtIsBeforeAndIsEndFalse(String uid, Pageable pageable, LocalDateTime now);
 }


### PR DESCRIPTION
당초 멤버 골에 필드를 추가하기로 한 사안이나, 우선 해당 유저의 목표 조회 요청 시,

투두 완료 비율을 계산하도록 로직을 짜놓았습니다.

당초 사안대로하려면, 투두의 업데이트가 일어날 때마다 갱신하는 로직이 추가되어야하는데,

투두 쪽은 개발 현재진행형인 점을 감안해서, 요청마다 연산되도록 해놓았습니다.

투두 쪽 개발 완료되는대로 같이 투두 완료 비율 필드 추가, 그리고 그 갱신 로직 같이 논의하여 반영하면 좋을 것 같습니다. 

API 의 리스폰스는 동일하니, 해당 로직으로 우선 배포해도 문제는 없습니다.

사실 당초 계획대로 하더라도, 어차피 유니크 인덱스로 조인된 투두들을 연산하는 것이라, 유의미한 퍼포먼스 상승은 기대하기 어려울 것 같습니다만... 어떻게 생각하시는 지 궁금하네요.